### PR TITLE
board一覧取得と詳細取得にuser.nameを含める修正

### DIFF
--- a/src/api/controller/AuthController.ts
+++ b/src/api/controller/AuthController.ts
@@ -77,7 +77,6 @@ export class AuthController {
     try {
       res.clearCookie("jwtToken", {
         httpOnly: true,
-        expires: new Date(Date.now() + 86400000), // 1日後の有効期限
       });
 
       res.status(200).json({ message: "Logout success" });

--- a/src/api/model/Board.ts
+++ b/src/api/model/Board.ts
@@ -3,7 +3,15 @@ import { prismaContext } from "../../lib/prismaContext";
 import { CustomException } from "../handler/exception/customError";
 
 export const getBoards = async () => {
-  const board = await prismaContext.board.findMany();
+  const board = await prismaContext.board.findMany({
+    include: {
+      user: {
+        select: {
+          name: true,
+        },
+      },
+    },
+  });
   return board;
 };
 
@@ -33,6 +41,13 @@ export const getBoard = async (existId: number): Promise<Board | null> => {
   const board = await prismaContext.board
     .findUniqueOrThrow({
       where: { id: existId },
+      include: {
+        user: {
+          select: {
+            name: true,
+          },
+        },
+      },
     })
     .catch(() => {
       return null;


### PR DESCRIPTION
### 実装目的

boardの取得apiに関連を持つuserテーブルのnameカラムを含めるように修正

### 検証手順

- 一覧取得
`http://localhost:3001/api/boards`

投稿したユーザーのnameがレスポンスに含まれていることを確認
```
{
    "message": "board get all is success",
    "boards": [
        {
            "id": 1,
            "title": "title01",
            "content": "content01",
            "boardImage": "",
            "userId": 1,
            "user": {
                "name": "user01"
            }
        },
        {
            "id": 2,
            "title": "title02",
            "content": "content02",
            "boardImage": "",
            "userId": 1,
            "user": {
                "name": "user02"
            }
        },
    ]
}
```

- 詳細取得
`http://localhost:3001/api/board/9`

投稿したユーザーのnameがレスポンスに含まれていることを確認
```
{
    "message": "this board get is success",
    "board": {
        "id": 1,
        "title": "title01",
        "content": "content01",
        "boardImage": "",
        "userId": 1,
        "user": {
            "name": "user01"
        }
    }
}
```

### 設計書

board一覧取得
https://implcojp.sharepoint.com/:x:/s/Times/EReatTa6ahhApRrA27_aTbUBRF4wP3X8MFMHfplCFwW0cA?e=EcVBYT

board詳細取得
https://implcojp.sharepoint.com/:x:/s/Times/ESyHtEOfFv9Il599N3VWAvIB0J_KO5R7C_I6Lwf_ZH74Hw?e=LVmTmQ

### 備考
