### PR TITLE
fix: jwtTokenのユーザーがUserテーブルに登録されているかの検証ミドルウェアの作成

### DIFF
--- a/src/api/controller/AuthController.ts
+++ b/src/api/controller/AuthController.ts
@@ -77,7 +77,6 @@ export class AuthController {
     try {
       res.clearCookie("jwtToken", {
         httpOnly: true,
-        expires: new Date(Date.now() + 86400000), // 1日後の有効期限
       });
 
       res.status(200).json({ message: "Logout success" });

--- a/src/api/controller/AuthController.ts
+++ b/src/api/controller/AuthController.ts
@@ -76,7 +76,7 @@ export class AuthController {
   async logout(req: Request, res: Response, next: NextFunction): Promise<void> {
     try {
       res.clearCookie("jwtToken", {
-        httpOnly: true,
+        httpOnly: true
       });
 
       res.status(200).json({ message: "Logout success" });

--- a/src/middleware/authenticateUser.ts
+++ b/src/middleware/authenticateUser.ts
@@ -24,10 +24,6 @@ const authenticateUser = async (req: Request, res: Response, next: NextFunction)
 
     const decode = await tokenDecode(token);
     const { email } = decode
-    
-    if (!decode) {
-      throw new CustomException(401, 'The token is invalid', "info");
-    }
 
     const user = await prisma.user.findUnique({ where: { email } });
 
@@ -42,7 +38,14 @@ const authenticateUser = async (req: Request, res: Response, next: NextFunction)
 };
 
 const tokenDecode = async (token: string): Promise<JwtPayload> => {
-  const decodedToken = await jwt.verify(token, jwtSecret) as JwtPayload;
+  let decodedToken: JwtPayload;
+
+  try {
+    decodedToken = await jwt.verify(token, jwtSecret) as JwtPayload;
+  } catch (error: any){
+    throw new CustomException(401, 'The token is invalid', "warn");
+  }
+  
   return decodedToken;
 };
 

--- a/src/middleware/authenticateUser.ts
+++ b/src/middleware/authenticateUser.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt, { JwtPayload } from 'jsonwebtoken';
+import dotenv from "dotenv";
+dotenv.config();
+
+const jwtSecret = process.env.JWT_SECRET_KEY || "";
+
+// JWTのデコードとユーザー確認を行うミドルウェア
+const authenticateUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const token = "";
+    const decode = await tokenDecode(token);
+
+  } catch (error) {
+    // デフォルトのエラークラスでthrow
+    throw new Error("Logout failed");
+  }
+  next();
+};
+
+const tokenDecode = async (token: string): Promise<JwtPayload> => {
+  const decodedToken = await jwt.verify(token, jwtSecret) as JwtPayload;
+  return decodedToken;
+};
+
+export = authenticateUser;

--- a/src/middleware/authenticateUser.ts
+++ b/src/middleware/authenticateUser.ts
@@ -8,12 +8,21 @@ const jwtSecret = process.env.JWT_SECRET_KEY || "";
 // JWTのデコードとユーザー確認を行うミドルウェア
 const authenticateUser = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const token = "";
+    const authHeader = req.headers['authorization'];
+    const token = authHeader && authHeader.split(' ')[1];
+
+    if (!token) {
+      return res.status(401).json({ message: 'Authentication is required' });
+    }
+
     const decode = await tokenDecode(token);
+    
+    if (!decode) {
+      return res.status(401).json({ message: 'The token is invalid' });
+    }
 
   } catch (error) {
-    // デフォルトのエラークラスでthrow
-    throw new Error("Logout failed");
+    return res.status(500).json({ message: 'The token verification failed' });
   }
   next();
 };

--- a/src/middleware/authenticateUser.ts
+++ b/src/middleware/authenticateUser.ts
@@ -2,6 +2,10 @@ import { Request, Response, NextFunction } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 import dotenv from "dotenv";
 import { PrismaClient } from '@prisma/client';
+import {
+  errorHandler,
+  CustomException
+} from "../api/handler/exception/customError";
 
 dotenv.config();
 
@@ -15,24 +19,24 @@ const authenticateUser = async (req: Request, res: Response, next: NextFunction)
     const token = authHeader && authHeader.split(' ')[1];
 
     if (!token) {
-      return res.status(401).json({ message: 'Authentication is required' });
+      throw new CustomException(401, 'Authentication is required', "info");
     }
 
     const decode = await tokenDecode(token);
     const { email } = decode
     
     if (!decode) {
-      return res.status(401).json({ message: 'The token is invalid' });
+      throw new CustomException(401, 'The token is invalid', "info");
     }
 
     const user = await prisma.user.findUnique({ where: { email } });
 
     if (!user) {
-      return res.status(401).json({ message: 'User not found' });
+      throw new CustomException(401, 'User not found', "info");
     }
 
-  } catch (error) {
-    return res.status(500).json({ message: 'The token verification failed' });
+  } catch (error: any) {
+    return next(errorHandler(error, res));
   }
   next();
 };

--- a/src/middleware/tokenVerify.ts
+++ b/src/middleware/tokenVerify.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 import dotenv from "dotenv";
-import { PrismaClient } from '@prisma/client';
 import {
   errorHandler,
   CustomException
@@ -10,7 +9,7 @@ import {
 dotenv.config();
 
 const jwtSecret = process.env.JWT_SECRET_KEY || "";
-const prisma = new PrismaClient();
+import { prismaContext } from "../lib/prismaContext";
 
 // JWTのデコードとユーザー確認を行うミドルウェア
 const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
@@ -25,7 +24,7 @@ const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
     const decode = await tokenDecode(token);
     const { email } = decode
 
-    const user = await prisma.user.findUnique({ where: { email } });
+    const user = await prismaContext.user.findUnique({ where: { email } });
 
     if (!user) {
       throw new CustomException(401, 'User not found', "info");

--- a/src/middleware/tokenVerify.ts
+++ b/src/middleware/tokenVerify.ts
@@ -29,11 +29,9 @@ const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
     
     const { email } = decode
     const user = await prismaContext.user.findUniqueOrThrow({ where: { email } })
-                                         .catch(() => { return null })
-
-    if (!user) {
-      throw new CustomException(401, 'User not found', "info");
-    }
+                                         .catch(() => { 
+                                          throw new CustomException(401, 'User not found', "info") 
+                                         });
 
   } catch (error: any) {
     return next(errorHandler(error, res));

--- a/src/middleware/tokenVerify.ts
+++ b/src/middleware/tokenVerify.ts
@@ -22,8 +22,12 @@ const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
     }
 
     const decode = await tokenDecode(token);
+    
+    if (!decode) {
+      throw new CustomException(401, 'The token is invalid', "warn");
+    }
+    
     const { email } = decode
-
     const user = await prismaContext.user.findUnique({ where: { email } });
 
     if (!user) {
@@ -36,16 +40,13 @@ const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
   next();
 };
 
-const tokenDecode = async (token: string): Promise<JwtPayload> => {
-  let decodedToken: JwtPayload;
-
+const tokenDecode = (token: string): JwtPayload | null => {
   try {
-    decodedToken = await jwt.verify(token, jwtSecret) as JwtPayload;
-  } catch (error: any){
-    throw new CustomException(401, 'The token is invalid', "warn");
+    const decodedToken = jwt.verify(token, jwtSecret) as JwtPayload;
+    return decodedToken;
+  } catch (error) {
+    return null;
   }
-  
-  return decodedToken;
 };
 
 export = tokenVerify;

--- a/src/middleware/tokenVerify.ts
+++ b/src/middleware/tokenVerify.ts
@@ -13,7 +13,7 @@ const jwtSecret = process.env.JWT_SECRET_KEY || "";
 const prisma = new PrismaClient();
 
 // JWTのデコードとユーザー確認を行うミドルウェア
-const authenticateUser = async (req: Request, res: Response, next: NextFunction) => {
+const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const authHeader = req.headers['authorization'];
     const token = authHeader && authHeader.split(' ')[1];
@@ -49,4 +49,4 @@ const tokenDecode = async (token: string): Promise<JwtPayload> => {
   return decodedToken;
 };
 
-export = authenticateUser;
+export = tokenVerify;

--- a/src/middleware/tokenVerify.ts
+++ b/src/middleware/tokenVerify.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 import dotenv from "dotenv";
+import { prismaContext } from "../lib/prismaContext";
 import {
   errorHandler,
   CustomException
@@ -9,7 +10,6 @@ import {
 dotenv.config();
 
 const jwtSecret = process.env.JWT_SECRET_KEY || "";
-import { prismaContext } from "../lib/prismaContext";
 
 // JWTのデコードとユーザー確認を行うミドルウェア
 const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {

--- a/src/middleware/tokenVerify.ts
+++ b/src/middleware/tokenVerify.ts
@@ -28,7 +28,8 @@ const tokenVerify = async (req: Request, res: Response, next: NextFunction) => {
     }
     
     const { email } = decode
-    const user = await prismaContext.user.findUnique({ where: { email } });
+    const user = await prismaContext.user.findUniqueOrThrow({ where: { email } })
+                                         .catch(() => { return null })
 
     if (!user) {
       throw new CustomException(401, 'User not found', "info");

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,8 @@
 import express from "express";
 const router = express.Router();
+const authenticateUser = require("../middleware/authenticateUser");
+
+router.use(authenticateUser);
 
 router.use("", require("./routes/hello"));
 router.use("", require("./routes/board"));

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,10 +1,9 @@
 import express from "express";
 const router = express.Router();
-const authenticateUser = require("../middleware/authenticateUser");
 
 router.use("", require("./routes/hello"));
 router.use("", require("./routes/auth"));
-router.use("", authenticateUser, require("./routes/board"));
-router.use("", authenticateUser, require("./routes/user"));
+router.use("", require("./routes/board"));
+router.use("", require("./routes/user"));
 
 module.exports = router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,11 +2,9 @@ import express from "express";
 const router = express.Router();
 const authenticateUser = require("../middleware/authenticateUser");
 
-router.use(authenticateUser);
-
 router.use("", require("./routes/hello"));
-router.use("", require("./routes/board"));
-router.use("", require("./routes/user"));
 router.use("", require("./routes/auth"));
+router.use("", authenticateUser, require("./routes/board"));
+router.use("", authenticateUser, require("./routes/user"));
 
 module.exports = router;

--- a/src/router/routes/auth.ts
+++ b/src/router/routes/auth.ts
@@ -2,7 +2,7 @@ import express, { Request, Response } from "express";
 const router = express.Router();
 const { AuthController } = require("../../api/controller/AuthController");
 const { validateError } = require("../../api/handler/rules/validateError");
-const authenticateUser = require("../../middleware/authenticateUser");
+const tokenVerify = require("../../middleware/tokenVerify");
 const {
   authRegisterRule,
   authLoginRule,
@@ -12,6 +12,6 @@ const authContext = new AuthController();
 
 router.post("/signup", authRegisterRule, validateError, authContext.register);
 router.post("/signin", authLoginRule, validateError, authContext.login);
-router.post("/signout", authenticateUser, authContext.logout);
+router.post("/signout", tokenVerify, authContext.logout);
 
 module.exports = router;

--- a/src/router/routes/auth.ts
+++ b/src/router/routes/auth.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 const router = express.Router();
 const { AuthController } = require("../../api/controller/AuthController");
 const { validateError } = require("../../api/handler/rules/validateError");
+const authenticateUser = require("../../middleware/authenticateUser");
 const {
   authRegisterRule,
   authLoginRule,
@@ -11,6 +12,6 @@ const authContext = new AuthController();
 
 router.post("/signup", authRegisterRule, validateError, authContext.register);
 router.post("/signin", authLoginRule, validateError, authContext.login);
-router.post("/signout", authContext.logout);
+router.post("/signout", authenticateUser, authContext.logout);
 
 module.exports = router;

--- a/src/router/routes/board.ts
+++ b/src/router/routes/board.ts
@@ -1,6 +1,7 @@
 import express from "express";
 const router = express.Router();
 const { BoardController } = require("../../api/controller/BoardController");
+const tokenVerify = require("../../middleware/tokenVerify");
 const {
   boardCreateRule,
   boardUpdateRule,
@@ -9,10 +10,10 @@ const { validateError } = require("../../api/handler/rules/validateError");
 
 const boardContext = new BoardController();
 
-router.get("/boards", boardContext.allBoard);
-router.post("/board", boardCreateRule, validateError, boardContext.postBoard);
-router.get("/board/:id", boardContext.showBoard);
-router.put("/board/:id", boardUpdateRule, validateError, boardContext.putBoard);
-router.delete("/board/:id", boardContext.deleteBoard);
+router.get("/boards", tokenVerify, boardContext.allBoard);
+router.post("/board", tokenVerify, boardCreateRule, validateError, boardContext.postBoard);
+router.get("/board/:id", tokenVerify, boardContext.showBoard);
+router.put("/board/:id", tokenVerify, boardUpdateRule, validateError, boardContext.putBoard);
+router.delete("/board/:id", tokenVerify, boardContext.deleteBoard);
 
 module.exports = router;

--- a/src/router/routes/user.ts
+++ b/src/router/routes/user.ts
@@ -1,12 +1,13 @@
 import express from "express";
-const router = express.Router();
 import { UserController } from "../../api/controller/UserController";
+const router = express.Router();
+const tokenVerify = require("../../middleware/tokenVerify");
 
 const userContext = new UserController();
 
-router.get("/users", userContext.allUser);
-router.put("/user/:id", userContext.putUser);
-router.get("/user/:id", userContext.showUser);
-router.delete("/user/:id", userContext.deleteUser);
+router.get("/users", tokenVerify, userContext.allUser);
+router.put("/user/:id", tokenVerify, userContext.putUser);
+router.get("/user/:id", tokenVerify, userContext.showUser);
+router.delete("/user/:id", tokenVerify, userContext.deleteUser);
 
 module.exports = router;


### PR DESCRIPTION
# 実装内容
- リクエストで送られてきたjwtTokenが正しいものなのか、
　jwtTokenを発行されたユーザーがUserテーブルに登録されているのかを検証するミドルウェアの作成

# 検証方法
Userテーブルにユーザーが登録されていることが条件
- signinAPIを叩き、tokenを控えておく
URL: http://localhost:3001/api/signin
bodyの例)
{
    "email": "sampleAddress@i.com",
    "password": "dfbgn8JBuiiiiihn3jiKyt53hbikdnfUI"
}
![スクリーンショット 2023-07-26 23 18 53](https://github.com/sayasurvey/queque_board_api/assets/89208789/12886d86-9731-4de4-83cb-6ebc445a8184)

- Postmanの場合、AuthタブでTypeをBearer Tokenを選択した後、Tokenに先ほど控えたjwtTokenを貼り付ける
![スクリーンショット 2023-07-26 23 22 41](https://github.com/sayasurvey/queque_board_api/assets/89208789/ea7d893e-cb0f-4ddf-83cb-fa8d218b98c7)

- Tokenの検証を行うAPIを叩く
例) URL: http://localhost:3001/api/user/1

# 設計書
- ありません

# 備考
- サインアップとサインインAPIはTokenの検証は除外しています